### PR TITLE
Optimize speed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ catalog.json
 state.json
 .target/
 notes.md
+logging.conf
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ catalog.json
 state.json
 .target/
 notes.md
-logging.conf
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/tap_slack/client.py
+++ b/tap_slack/client.py
@@ -10,6 +10,7 @@ from slack.errors import SlackApiError
 from urllib.error import URLError
 
 LOGGER = singer.get_logger()
+max_tries = 5
 backoff_exceptions = (SlackApiError, TimeoutError, ConnectionResetError, URLError)
 
 
@@ -38,7 +39,7 @@ class SlackClient(object):
 
     @backoff.on_exception(backoff.constant,
                           backoff_exceptions,
-                          max_tries=2,
+                          max_tries=max_tries,
                           jitter=None,
                           giveup=wait,
                           interval=0)
@@ -50,7 +51,7 @@ class SlackClient(object):
 
     @backoff.on_exception(backoff.constant,
                           backoff_exceptions,
-                          max_tries=2,
+                          max_tries=max_tries,
                           jitter=None,
                           giveup=wait,
                           interval=0)
@@ -61,7 +62,7 @@ class SlackClient(object):
 
     @backoff.on_exception(backoff.constant,
                           backoff_exceptions,
-                          max_tries=2,
+                          max_tries=max_tries,
                           jitter=None,
                           giveup=wait,
                           interval=0)
@@ -80,12 +81,13 @@ class SlackClient(object):
 
     @backoff.on_exception(backoff.constant,
                           backoff_exceptions,
-                          max_tries=2,
+                          max_tries=max_tries,
                           jitter=None,
                           giveup=wait,
                           interval=0)
     def get_messages(self, channel, oldest, latest):
         try:
+            LOGGER.info(f"Attempting a get_messages API call for channel: {channel}")
             messages = self.webclient \
                 .conversations_history(channel=channel,
                                        oldest=oldest,
@@ -109,7 +111,7 @@ class SlackClient(object):
 
     @backoff.on_exception(backoff.constant,
                           backoff_exceptions,
-                          max_tries=2,
+                          max_tries=max_tries,
                           jitter=None,
                           giveup=wait,
                           interval=0)
@@ -122,7 +124,7 @@ class SlackClient(object):
 
     @backoff.on_exception(backoff.constant,
                           backoff_exceptions,
-                          max_tries=2,
+                          max_tries=max_tries,
                           jitter=None,
                           giveup=wait,
                           interval=0)
@@ -131,7 +133,7 @@ class SlackClient(object):
 
     @backoff.on_exception(backoff.constant,
                           backoff_exceptions,
-                          max_tries=2,
+                          max_tries=max_tries,
                           jitter=None,
                           giveup=wait,
                           interval=0)
@@ -142,7 +144,7 @@ class SlackClient(object):
 
     @backoff.on_exception(backoff.constant,
                           backoff_exceptions,
-                          max_tries=2,
+                          max_tries=max_tries,
                           jitter=None,
                           giveup=wait,
                           interval=0)
@@ -151,7 +153,7 @@ class SlackClient(object):
 
     @backoff.on_exception(backoff.constant,
                           backoff_exceptions,
-                          max_tries=2,
+                          max_tries=max_tries,
                           jitter=None,
                           giveup=wait,
                           interval=0)
@@ -160,7 +162,7 @@ class SlackClient(object):
 
     @backoff.on_exception(backoff.constant,
                           backoff_exceptions,
-                          max_tries=2,
+                          max_tries=max_tries,
                           jitter=None,
                           giveup=wait,
                           interval=0)
@@ -169,7 +171,7 @@ class SlackClient(object):
 
     @backoff.on_exception(backoff.constant,
                           backoff_exceptions,
-                          max_tries=2,
+                          max_tries=max_tries,
                           jitter=None,
                           giveup=wait,
                           interval=0)


### PR DESCRIPTION
Not a lot of code, but a far more optimized tap. 

* Findings:
    - The main API-rate-limiting-bottleneck for us has occurred when calling [`tap_slack.client.SlackClient.get_thread()`](https://github.com/singer-io/tap-slack/blob/master/tap_slack/client.py#L99-L110). What I realized was that in order to pull the [`Threads`](https://api.slack.com/messaging/managing#threading) stream, it requires [making a call to the API _for every message_](https://github.com/singer-io/tap-slack/blob/master/tap_slack/streams.py#L260-L267). Practically speaking, this means adding about about [4k extra API calls to our `tap-slack` per weekday](https://immuta.slack.com/stats). This poses two main challenges which compound and result in a _slow_ tap.
        1. First, The most data-intensive API calls are the [message](https://api.slack.com/methods/conversations.history)/[thread](https://api.slack.com/methods/conversations.replies)-associated ones, which are both [Tier-3 rate-limited](https://api.slack.com/docs/rate-limits), meaning that we can freely call them at least 50 times per minute. Even operating at the maximal 50 API calls per minute, it would take us (assuming all other parts of the tap run instantaneously) 80 minutes to pull all messages+threads for a single weekday.
        2. Second, we can quantify _exactly_ how long each [`tap_slack.client.SlackClient.get_thread()`](https://github.com/singer-io/tap-slack/blob/master/tap_slack/client.py#L99-L110) call takes. On average, it takes about 0.44 seconds. So, if we add that computational time to each of our messages for a given weekday - (4000 messages * 0.44 seconds)/60 = 30 minutes - we can tack another 30 minutes of running time to our tap for each day. Yikes.
    - For the aforementioned reasons, I've chosen to omit the `Threads` stream from our `catalog.json`.
* Code contributions:
    - Improved fault-tolerancy, even after exceeding maximal retries. In this scenario, data will be lost, but the exceptions are handled and appropriately logged.